### PR TITLE
Rewrite to match style of Hapi 17.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 
 node_js:
-  - 4
-  - 6
+  - 8
 
 services: mongodb
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release:major": "npm run ci && release-it -n -i major"
   },
   "engines": {
-    "node": ">=4.x.x"
+    "node": ">=8.x.x"
   },
   "repository": {
     "type": "git",
@@ -30,6 +30,9 @@
   "homepage": "https://github.com/aptoma/hapi-mongoose-helper",
   "eslintConfig": {
     "extends": "@aptoma/eslint-config",
+    "parserOptions": {
+      "ecmaVersion": "2017"
+    },
     "env": {
       "node": true,
       "mocha": true,
@@ -37,19 +40,19 @@
     }
   },
   "dependencies": {
-    "boom": "^5.2.0",
-    "hoek": "^4.2.0"
+    "boom": "^7.1.1",
+    "hoek": "^5.0.2"
   },
   "devDependencies": {
     "@aptoma/eslint-config": "^7.0.1",
-    "bluebird": "^3.5.0",
+    "bluebird": "^3.5.1",
     "chai": "^4.1.2",
-    "eslint": "^4.6.1",
-    "hapi": "^16.5.2",
+    "eslint": "^4.12.1",
+    "hapi": "^17.1.1",
     "istanbul": "^0.4.2",
-    "mocha": "^3.5.0",
+    "mocha": "^4.0.1",
     "mocha-only-detector": "^0.1.0",
-    "mongoose": "^4.11.10",
+    "mongoose": "^4.13.6",
     "release-it": "^2.8.5"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -61,28 +61,24 @@ describe('Database Service', () => {
 		it('should match old dup key error message', () => {
 			const err = new Error('E11000 duplicate key error index: dredition-test.editions.$name_1_product_1 dup key: { : "morning-edition", : ObjectId(\'555c3e9843825487310041a7\') }');
 
-			db.duplicateKeyError((err) => {
-				assert.equal(err.message, 'Duplicate key error: name_1_product_1');
-			})(err);
+			assert.throws(db.duplicateKeyError().bind(null, err), 'Duplicate key error: name_1_product_1');
 		});
 
 		it('should match new dup key error message', () => {
 			const err = new Error('E11000 duplicate key error collection: dredition-test.editions index: name_1_product_1 dup key: { : "morning-edition", : ObjectId(\'555c3e9843825487310041a7\') }');
 
-			db.duplicateKeyError((err) => {
-				assert.equal(err.message, 'Duplicate key error: name_1_product_1');
-			})(err);
+			assert.throws(db.duplicateKeyError().bind(null, err), 'Duplicate key error: name_1_product_1');
 		});
 	});
 
 
-	describe('validateErrorReply()', () => {
+	describe('validationError()', () => {
 
 		it('should rethrow error if not an ValidationError', () => {
 			return new Promise(() => {
 				throw new Error('crap');
 			})
-				.catch(db.validationErrorReply())
+				.catch(db.validationError)
 				.catch((e) => {
 					assert.equal(e.message, 'crap');
 				});
@@ -102,13 +98,14 @@ describe('Database Service', () => {
 				};
 				throw e;
 			})
-				.catch(db.validationErrorReply((err) => {
+				.catch(db.validationError)
+				.catch((err) => {
 					assert.deepEqual(err.output.payload, {
 						statusCode: 400,
 						error: 'Bad Request',
 						message: 'Validation failed: Failed to validate item: should have required property \'title\''
 					});
-				}));
+				});
 		});
 
 	});


### PR DESCRIPTION
- Require node 8
- duplicateKeyError now throws and doesn’t take any argument
- validateErrorReply renamed to validationError and doesn’t take any argument or return a function and throws
- mongoErrorReply renamed to mongoError and doesn’t take any argument or return a function and throws