### PR TITLE
Support more result types in notFoundExceptionIfNoMatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,8 +78,20 @@ function notFoundExceptionIfNoMatch(res) {
 		throw new NotFoundException('Empty database result');
 	}
 
-	// support both update result and remove result
-	const n = res.n !== undefined ? res.n : Hoek.reach(res, 'result.n');
+	// support mixed types of results
+	let n;
+
+	if (res.n !== undefined) {
+		n = res.n;
+	}
+
+	if (res.result?.n !== undefined) {
+		n = res.result.n;
+	}
+
+	if (res.matchedCount !== undefined) {
+		n = res.matchedCount;
+	}
 
 	// n is the number of matched document
 	// more info on response here https://docs.mongodb.org/manual/reference/command/update/#update-command-output

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -55,6 +55,23 @@ describe('Database Service', () => {
 
 	});
 
+	describe('notFoundExceptionIfNoMatch', () => {
+		it('supports res.n', () => {
+			db.notFoundExceptionIfNoMatch({n: 1});
+			assert.throws(() => db.notFoundExceptionIfNoMatch({n: 0}), 'No document matched for update');
+		});
+
+		it('supports res.result.n', () => {
+			db.notFoundExceptionIfNoMatch({result: {n: 1}});
+			assert.throws(() => db.notFoundExceptionIfNoMatch({result: {n: 0}}), 'No document matched for update');
+		});
+
+		it('supports res.matchedCount', () => {
+			db.notFoundExceptionIfNoMatch({matchedCount: 1});
+			assert.throws(() => db.notFoundExceptionIfNoMatch({matchedCount: 0}), 'No document matched for update');
+		});
+	});
+
 	describe('duplicateKeyError()', () => {
 
 		it('should match old dup key error message', () => {


### PR DESCRIPTION
In mongoose 6 there seem to be a change in result from `Query.updateOne` that returns `matchedCount` but it shouldn't according to the docs. Fixed so that we support all know types of result for updates.

`matchedCount` comes from `update` or `updateMany` in the mongodb driver